### PR TITLE
Laravel 10 Compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 sftp-config.json
 vendor
 composer.lock
+.phpunit.cache
 .phpunit.result.cache
-
 \.idea/

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This library was originally built by LibiChai based on the RedLock algorithm dev
 | 7.x             | `^7.0`          |
 | 8.x             | `^8.0`          |
 | 9.x             | `^9.0`          |
+| 10.x            | `^10.0`         |
 
 ### It's Simple!
 

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
     ],
     "require": {
       "php": ">=8.0.0",
-      "illuminate/support": "^9.0",
-      "illuminate/console": "^9.0",
+      "illuminate/support": "^10.0",
+      "illuminate/console": "^10.0",
       "predis/predis": "^2.0"
     },
     "require-dev": {
-      "orchestra/testbench": "^7.0",
-      "php-mock/php-mock-mockery": "^1.1",
-      "phpunit/phpunit": "^9.0"
+      "orchestra/testbench": "^8.0",
+      "php-mock/php-mock-mockery": "^1.4",
+      "phpunit/phpunit": "^10.0"
     },
     "autoload": {
       "psr-4": {
@@ -52,4 +52,3 @@
     },
     "minimum-stability": "stable"
   }
-  

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         >
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    backupGlobals="false"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false">
+    <coverage />
     <testsuites>
         <testsuite name="ModelViewer Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-            <exclude>
-                <file>app/Http/routes.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
     <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <env name="SESSION_DRIVER" value="array"/>
-        <env name="QUEUE_DRIVER" value="sync"/>
+        <env name="APP_ENV" value="testing" />
+        <env name="CACHE_DRIVER" value="array" />
+        <env name="SESSION_DRIVER" value="array" />
+        <env name="QUEUE_DRIVER" value="sync" />
     </php>
+    <source>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+        <exclude>
+            <file>app/Http/routes.php</file>
+        </exclude>
+    </source>
 </phpunit>


### PR DESCRIPTION
This PR makes the package compatible with Laravel 10.x. This was simply achieved by upgrading the dependent packages as below:

### Dependencies
* `illuminate/console` from `v.9.x` to `v10.x`
* `illuminate/support` from `v.9.x` to `v10.x`

In addition, dev dependencies mainly for testing has been updated to their respective latest versions; most notably, `PHPUNIT` to `v10`.